### PR TITLE
Add support for Swift 4

### DIFF
--- a/bin/steps/swift-install
+++ b/bin/steps/swift-install
@@ -3,7 +3,9 @@ mkdir -p $BUILD_DIR/.swift-lib
 SWIFT_PREFIX="$(swiftenv prefix)"
 cp $SWIFT_PREFIX/usr/lib/swift/linux/*.so $BUILD_DIR/.swift-lib
 find $BUILD_DIR/.build/$SWIFT_BUILD_CONFIGURATION -name '*.so' -type f -exec cp {} $BUILD_DIR/.swift-lib \;
+find $BUILD_DIR/.build/x86_64-unknown-linux/$SWIFT_BUILD_CONFIGURATION -name '*.so' -type f -exec cp {} $BUILD_DIR/.swift-lib \;
 
 puts-step "Installing binaries"
 mkdir -p $BUILD_DIR/.swift-bin
 find $BUILD_DIR/.build/$SWIFT_BUILD_CONFIGURATION ! -name '*.so' -type f -perm /a+x -exec cp {} $BUILD_DIR/.swift-bin \;
+find $BUILD_DIR/.build/x86_64-unknown-linux/$SWIFT_BUILD_CONFIGURATION ! -name '*.so' -type f -perm /a+x -exec cp {} $BUILD_DIR/.swift-bin \;

--- a/bin/steps/swift-install
+++ b/bin/steps/swift-install
@@ -4,6 +4,7 @@ SWIFT_PREFIX="$(swiftenv prefix)"
 cp $SWIFT_PREFIX/usr/lib/swift/linux/*.so $BUILD_DIR/.swift-lib
 find $BUILD_DIR/.build/$SWIFT_BUILD_CONFIGURATION -name '*.so' -type f -exec cp {} $BUILD_DIR/.swift-lib \;
 find $BUILD_DIR/.build/x86_64-unknown-linux/$SWIFT_BUILD_CONFIGURATION -name '*.so' -type f -exec cp {} $BUILD_DIR/.swift-lib \;
+cp -av /usr/lib/x86_64-linux-gnu/libatomic* $BUILD_DIR/.swift-lib
 
 puts-step "Installing binaries"
 mkdir -p $BUILD_DIR/.swift-bin


### PR DESCRIPTION
This PR makes the buildpack magically work with Swift 4 projects:
- swiftenv is updated to the latest version so the Swift 4 toolchains can be installed successfully;
- binaries (executable and shared libraries alike) are copied from both `.build/release` (Swift 3) and `.build/x86_64-unknown-linux/release` (Swift 4);
- and there's a new runtime dependency `libatomic.so.1`, which is not present in the runtime image, is now manually copied into `.swift-lib`.