### PR TITLE
Fix pre-compile hook

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -30,6 +30,8 @@ source "/etc/lsb-release"
 source "$BIN_DIR/utils"
 source "$BIN_DIR/steps/clang"
 source "$BIN_DIR/steps/swiftenv"
+
+cd $BUILD_DIR
 source "$BIN_DIR/steps/hooks/pre_compile"
 source "$BIN_DIR/steps/swift-build"
 source "$BIN_DIR/steps/swift-install"

--- a/bin/steps/swift-build
+++ b/bin/steps/swift-build
@@ -1,4 +1,2 @@
-cd $BUILD_DIR
-
 puts-step "Building package"
 swift build $SWIFT_BUILD_FLAGS -c release


### PR DESCRIPTION
Previously, the pre-compile hook was never found and thus never executed because it was searched in the buildpack repo, not in the app repo. By moving `cd $BUILD_DIR` out of the `swift-build` step, I make this environment change clearer than it would be when it would have been buried inside of the `hooks/pre_compile` step.