### PR TITLE
Add SSH keys if available

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -33,6 +33,7 @@ source "$BIN_DIR/steps/swiftenv"
 
 cd $BUILD_DIR
 source "$BIN_DIR/steps/hooks/pre_compile"
+source "$BIN_DIR/steps/ssh"
 source "$BIN_DIR/steps/swift-build"
 source "$BIN_DIR/steps/swift-install"
 

--- a/bin/steps/ssh
+++ b/bin/steps/ssh
@@ -1,0 +1,14 @@
+# Used from https://github.com/IBM-Swift/swift-buildpack/blob/master/bin/compile.sh
+if [ -f $BUILD_DIR/.ssh/config ]; then
+    puts-step "Add SSH keys to known hosts"
+    mkdir -p ~/.ssh
+    touch ~/.ssh/known_hosts
+    cp $BUILD_DIR/.ssh/* ~/.ssh
+
+    # Add hosts to known_hosts file
+    grep HostName ~/.ssh/config | while read line
+    do
+        SSHKey=$(ssh-keyscan -t rsa ${line//HostName } 2> /dev/null)
+        echo $SSHKey >> ~/.ssh/known_hosts
+    done
+fi

--- a/bin/steps/ssh
+++ b/bin/steps/ssh
@@ -1,6 +1,6 @@
 # Used from https://github.com/IBM-Swift/swift-buildpack/blob/master/bin/compile.sh
 if [ -f $BUILD_DIR/.ssh/config ]; then
-    puts-step "Add SSH keys to known hosts"
+    puts-step "Adding SSH keys"
     mkdir -p ~/.ssh
     touch ~/.ssh/known_hosts
     cp $BUILD_DIR/.ssh/* ~/.ssh


### PR DESCRIPTION
This PR adds logic from the Kitura buildpack to support adding keys from `.ssh` to the known hosts https://github.com/IBM-Swift/swift-buildpack/blob/master/bin/compile.sh#L154