### PR TITLE
Add Custom Project Folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ remote: -----> Building package (debug configuration)
 ...
 ```
 
+### Custom app folder
+
+By default, the buildpack will use the root project folder to detect and build you app.
+If you want to use a custom project folder set the `PROJECT_PATH` Config Var to the relative app folder.
+
 ### Hooks
 
 You can place custom scripts to be ran before and after compiling your Swift

--- a/bin/compile
+++ b/bin/compile
@@ -25,9 +25,8 @@ if [ -f "$ENV_DIR/SWIFT_BUILD_FLAGS" ]; then
 fi
 if [ -f "$ENV_DIR/PROJECT_PATH" ]; then
   PROJECT_PATH=`cat "$ENV_DIR/PROJECT_PATH"`
-  mv $BUILD_DIR/$PROJECT_PATH/* .
+  mv $BUILD_DIR/$PROJECT_PATH/* $BUILD_DIR/
   rm -rf $BUILD_DIR/$PROJECT_PATH
-  cd $BIN_DIR
 fi
 
 mkdir -p "$CACHE_DIR/$STACK"

--- a/bin/compile
+++ b/bin/compile
@@ -25,8 +25,8 @@ if [ -f "$ENV_DIR/SWIFT_BUILD_FLAGS" ]; then
 fi
 if [ -f "$ENV_DIR/PROJECT_PATH" ]; then
   PROJECT_PATH=`cat "$ENV_DIR/PROJECT_PATH"`
-  mv -v $BUILD_DIR/$PROJECT_PATH/* .
-  rm -rfv $BUILD_DIR/$PROJECT_PATH
+  mv $BUILD_DIR/$PROJECT_PATH/* .
+  rm -rf $BUILD_DIR/$PROJECT_PATH
   cd $BIN_DIR
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# bin/compile <build-dir> <cache-dir>
+# bin/compile <build-dir> <cache-dir> <env-dir>
 
 set -e
 set -o pipefail
@@ -22,6 +22,12 @@ if [ -f "$ENV_DIR/SWIFT_BUILD_CONFIGURATION" ]; then
 fi
 if [ -f "$ENV_DIR/SWIFT_BUILD_FLAGS" ]; then
   SWIFT_BUILD_FLAGS=`cat "$ENV_DIR/SWIFT_BUILD_FLAGS"`
+fi
+if [ -f "$ENV_DIR/PROJECT_PATH" ]; then
+  PROJECT_PATH=`cat "$ENV_DIR/PROJECT_PATH"`
+  mv -v $BUILD_DIR/$PROJECT_PATH/* .
+  rm -rfv $BUILD_DIR/$PROJECT_PATH
+  cd $BIN_DIR
 fi
 
 mkdir -p "$CACHE_DIR/$STACK"

--- a/bin/detect
+++ b/bin/detect
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # bin/detect <build-dir>
 
-if [[ -f $1/Package.swift ]]; then
+if [[ `find .  -iname "Package.swift"` ]]; then
   echo "Swift" && exit 0
 else
   echo "no" && exit 1

--- a/bin/detect
+++ b/bin/detect
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # bin/detect <build-dir>
 
-if [[ `find .  -iname "Package.swift"` ]]; then
+if [[ `find $1 -iname "Package.swift"` ]]; then
   echo "Swift" && exit 0
 else
   echo "no" && exit 1


### PR DESCRIPTION
This PR adds support for a custom project folder, useful if you have a multi-purpose repo.
It works by setting a `PROJECT_PATH` Config Var with the right project folder, like `Server`.
I'm already using it inside my private project, maybe this can be useful to others.

### How it works
For the detect steps, it searches for a Package.swift file in all the project folders.

For the build steps, it checks for a `PROJECT_PATH` Config Var and then:
- Moves the custom project folder to the build folder
- Removes the custom project folder to free disk space

