### PR TITLE
Halt build on heroku-18 stack

### DIFF
--- a/bin/steps/clang
+++ b/bin/steps/clang
@@ -1,3 +1,15 @@
+if [ $STACK == "heroku-18" ]
+then
+  echo
+  echo " ! This buildpack does not support the heroku-18 stack at the moment."
+  echo " ! Downgrade your application to the heroku-16 stack with the following command:"
+  echo "     $ heroku stack:set heroku-16 -a <your-application-name>"
+  echo
+  echo " ! Then deploy the application again."
+  echo
+  exit 1
+fi
+
 if [[ ! -d "$CACHE_DIR/$STACK/clang-$CLANG_VERSION" ]]; then
   puts-step "Installing clang $CLANG_VERSION"
   mkdir -p "$CACHE_DIR/$STACK/clang-$CLANG_VERSION"


### PR DESCRIPTION
This PR adds a helpful error message when deployed on heroku-18 (the current default for new applications) as a workaround for #23.