### PR TITLE
Ensure submodule update  in the correct directory

### DIFF
--- a/bin/steps/swiftenv
+++ b/bin/steps/swiftenv
@@ -1,6 +1,13 @@
 # Fetch swiftenv
 puts-step Installing swiftenv
+
+#make sure the git submodule update command is ran in the correct directory
+pushd "$ROOT_DIR" > /dev/null
+
 git submodule update --init --recursive >/dev/null
+
+#now move back to the previous directory
+popd > /dev/null
 
 # Activate swiftenv
 export SWIFTENV_ROOT="$CACHE_DIR/$STACK/swiftenv"


### PR DESCRIPTION
When using [dokku](github.com/dokku/dokku) to deploy a vapor application with this buildpack,  initializing the swiftenv submodule would fail because the current directory is incorrect, with the following error: `fatal: Not a git repository (or any of the parent directories): .git`.
This PR adds `pushd` and `popd` to make sure the `git submodule update --init` is called from the correct place without throwing any errors.