### PR TITLE
Source `pre_compile` Hook

### DIFF
--- a/bin/steps/hooks/pre_compile
+++ b/bin/steps/hooks/pre_compile
@@ -2,6 +2,5 @@
 
 if [ -f bin/pre_compile ]; then
   echo "-----> Running pre-compile hook"
-  chmod +x bin/pre_compile
-  ./bin/pre_compile
+  source ./bin/pre_compile
 fi


### PR DESCRIPTION
Sourcing the `bin/pre_compile` hook allows it to set environment variables for the remainder of the buildpack's execution.