### PR TITLE
Restore support for Swift 5.1.5

### DIFF
--- a/swiftenv/CHANGELOG.md
+++ b/swiftenv/CHANGELOG.md
@@ -17,6 +17,9 @@
   Linux distributions such as Elementary OS and use the appropriate binary
   image from swift.org.
 
+- On macOS, `swiftenv install` now accepts `--user` command which allows you to
+  install Swift into your home directory instead of requiring root.
+
 ### Bug Fixes
 
 - On macOS, `swiftenv uninstall` would fail to uninstall some installed binary

--- a/swiftenv/Makefile
+++ b/swiftenv/Makefile
@@ -9,7 +9,14 @@ test-integration:
 bats:
 	git clone --depth 1 https://github.com/sstephenson/bats.git
 
-CACHED_VERSIONS := 3.0 3.0.1 3.0.2 3.1 3.1.1 4.0 4.0.2 4.0.3 4.1 4.1.1 4.1.2 4.1.3 4.2 4.2.1 4.2.2
+CACHED_VERSIONS := 3.0 3.0.1 3.0.2 \
+  3.1 3.1.1 \
+  4.0 4.0.2 4.0.3 \
+  4.1 4.1.1 4.1.2 4.1.3 \
+  4.2 4.2.1 4.2.2 4.2.3 4.2.4 \
+  5.0 5.0.1 5.0.2 5.0.3 \
+  5.1 5.1.1 5.1.2 5.1.3 5.1.4 5.1.5
+
 CACHED_PATHS := $(foreach version,$(CACHED_VERSIONS),share/swiftenv-install/$(version))
 versions: $(CACHED_PATHS)
 

--- a/swiftenv/libexec/swiftenv-install
+++ b/swiftenv/libexec/swiftenv-install
@@ -221,7 +221,6 @@ get_version_list() {
 
   if ([ "$build" == "false" ]); then
     VERSIONS="$(ls "$SWIFTENV_SOURCE_PATH/share/swiftenv-install" | grep -v json | sort_versions | uniq)"
-    PLATFORM="$(get_platform)"
 
     for version in $VERSIONS; do
       URL=""
@@ -358,6 +357,7 @@ if [[ "$VERSION" == "https://"* ]]; then
 fi
 
 VERSION="${VERSION##swift-}"
+PLATFORM="$(get_platform)"
 
 check_installed "$VERSION"
 

--- a/swiftenv/libexec/swiftenv-install
+++ b/swiftenv/libexec/swiftenv-install
@@ -141,7 +141,11 @@ install_pkg_binary() {
 
   download "$URL" "$PKG"
 
-  sudo installer -pkg "$PKG" -target /
+  if $user; then
+    installer -pkg "$PKG" -target CurrentUserHomeDirectory
+  else
+    sudo installer -pkg "$PKG" -target LocalSystem
+  fi
 
   if $clean; then
     rm -fr "$PKG"
@@ -243,6 +247,11 @@ verify=false
 set_global=auto
 set_local=false
 completes=false
+user=true
+
+if [ "$(uname)" == "Darwin" ]; then
+  user=false
+fi
 
 if [ -n "$SWIFTENV_VERIFY" ] && [ "$SWIFTENV_VERIFY" != "false" ]; then
   verify=true
@@ -284,6 +293,10 @@ for args in "$@"; do
     set_global=true
   elif [ "$args" = "--set-local" ]; then
     set_local=true
+  elif [ "$args" = "--user" ]; then
+    user=true
+  elif [ "$args" = "--no-user" ]; then
+    user=false
   else
     VERSION="$args"
   fi
@@ -310,6 +323,8 @@ if $completes; then
   echo "--no-set-global"
   echo "--set-local"
   echo "--no-set-local"
+  echo "--user"
+  echo "--no-user"
   get_version_list
   exit
 fi
@@ -345,6 +360,13 @@ fi
 VERSION="${VERSION##swift-}"
 
 check_installed "$VERSION"
+
+if ! $user; then
+  if [ "$(uname)" != "Darwin" ]; then
+    echo "--no-user installation is only supported on macOS."
+    exit 1
+  fi
+fi
 
 # Install Binary
 if ([ "$build" == "auto" ] || [ "$build" == "false" ]); then

--- a/swiftenv/share/man/man1/swiftenv-install.1
+++ b/swiftenv/share/man/man1/swiftenv-install.1
@@ -4,7 +4,7 @@
 swiftenv-install \- Install a version of Swift
 
 .SH SYNOPSIS
-swiftenv install [\-\-verbose] [\-\-list] [\-\-list-snapshots] [\-\-[no\-]build] [\-\-[no\-]set\-global] [\-\-[no\-]set\-local] [--no-clean] <version>
+swiftenv install [\-\-verbose] [\-\-list] [\-\-list-snapshots] [\-\-[no\-]build] [\-\-[no\-]set\-global] [\-\-[no\-]set\-local] [--no-clean] [\-\-[no\-]user] <version>
 
 .SH DESCRIPTION
 
@@ -77,4 +77,18 @@ Set the installed version in the local .swift-version file.
 
 .RS
 Don't set the installed version locally.
+.RE
+
+
+\-\-user
+
+.RS
+Install to the swiftenv user install directory for your platform. Typically ~/.swiftenv/versions
+.RE
+
+
+\-\-no\-user
+
+.RS
+Install to the swiftenv system install directory for your platform. On macOS this is in /Library
 .RE

--- a/swiftenv/share/swiftenv-install/4.2.3
+++ b/swiftenv/share/swiftenv-install/4.2.3
@@ -1,0 +1,20 @@
+case "$PLATFORM" in
+  'osx' )
+    URL="https://swift.org/builds/swift-4.2.3-release/xcode/swift-4.2.3-RELEASE/swift-4.2.3-RELEASE-osx.pkg"
+    ;;
+
+  'ubuntu14.04' )
+    URL="https://swift.org/builds/swift-4.2.3-release/ubuntu1404/swift-4.2.3-RELEASE/swift-4.2.3-RELEASE-ubuntu14.04.tar.gz"
+    ;;
+
+  'ubuntu16.04' )
+    URL="https://swift.org/builds/swift-4.2.3-release/ubuntu1604/swift-4.2.3-RELEASE/swift-4.2.3-RELEASE-ubuntu16.04.tar.gz"
+    ;;
+
+  'ubuntu18.04' )
+    URL="https://swift.org/builds/swift-4.2.3-release/ubuntu1804/swift-4.2.3-RELEASE/swift-4.2.3-RELEASE-ubuntu18.04.tar.gz"
+    ;;
+
+  * )
+    ;;
+esac

--- a/swiftenv/share/swiftenv-install/4.2.4
+++ b/swiftenv/share/swiftenv-install/4.2.4
@@ -1,0 +1,20 @@
+case "$PLATFORM" in
+  'osx' )
+    URL="https://swift.org/builds/swift-4.2.4-release/xcode/swift-4.2.4-RELEASE/swift-4.2.4-RELEASE-osx.pkg"
+    ;;
+
+  'ubuntu14.04' )
+    URL="https://swift.org/builds/swift-4.2.4-release/ubuntu1404/swift-4.2.4-RELEASE/swift-4.2.4-RELEASE-ubuntu14.04.tar.gz"
+    ;;
+
+  'ubuntu16.04' )
+    URL="https://swift.org/builds/swift-4.2.4-release/ubuntu1604/swift-4.2.4-RELEASE/swift-4.2.4-RELEASE-ubuntu16.04.tar.gz"
+    ;;
+
+  'ubuntu18.04' )
+    URL="https://swift.org/builds/swift-4.2.4-release/ubuntu1804/swift-4.2.4-RELEASE/swift-4.2.4-RELEASE-ubuntu18.04.tar.gz"
+    ;;
+
+  * )
+    ;;
+esac

--- a/swiftenv/share/swiftenv-install/5.0
+++ b/swiftenv/share/swiftenv-install/5.0
@@ -1,0 +1,20 @@
+case "$PLATFORM" in
+  'osx' )
+    URL="https://swift.org/builds/swift-5.0-release/xcode/swift-5.0-RELEASE/swift-5.0-RELEASE-osx.pkg"
+    ;;
+
+  'ubuntu14.04' )
+    URL="https://swift.org/builds/swift-5.0-release/ubuntu1404/swift-5.0-RELEASE/swift-5.0-RELEASE-ubuntu14.04.tar.gz"
+    ;;
+
+  'ubuntu16.04' )
+    URL="https://swift.org/builds/swift-5.0-release/ubuntu1604/swift-5.0-RELEASE/swift-5.0-RELEASE-ubuntu16.04.tar.gz"
+    ;;
+
+  'ubuntu18.04' )
+    URL="https://swift.org/builds/swift-5.0-release/ubuntu1804/swift-5.0-RELEASE/swift-5.0-RELEASE-ubuntu18.04.tar.gz"
+    ;;
+
+  * )
+    ;;
+esac

--- a/swiftenv/share/swiftenv-install/5.0.1
+++ b/swiftenv/share/swiftenv-install/5.0.1
@@ -1,0 +1,20 @@
+case "$PLATFORM" in
+  'osx' )
+    URL="https://swift.org/builds/swift-5.0.1-release/xcode/swift-5.0.1-RELEASE/swift-5.0.1-RELEASE-osx.pkg"
+    ;;
+
+  'ubuntu14.04' )
+    URL="https://swift.org/builds/swift-5.0.1-release/ubuntu1404/swift-5.0.1-RELEASE/swift-5.0.1-RELEASE-ubuntu14.04.tar.gz"
+    ;;
+
+  'ubuntu16.04' )
+    URL="https://swift.org/builds/swift-5.0.1-release/ubuntu1604/swift-5.0.1-RELEASE/swift-5.0.1-RELEASE-ubuntu16.04.tar.gz"
+    ;;
+
+  'ubuntu18.04' )
+    URL="https://swift.org/builds/swift-5.0.1-release/ubuntu1804/swift-5.0.1-RELEASE/swift-5.0.1-RELEASE-ubuntu18.04.tar.gz"
+    ;;
+
+  * )
+    ;;
+esac

--- a/swiftenv/share/swiftenv-install/5.0.2
+++ b/swiftenv/share/swiftenv-install/5.0.2
@@ -1,0 +1,20 @@
+case "$PLATFORM" in
+  'osx' )
+    URL="https://swift.org/builds/swift-5.0.2-release/xcode/swift-5.0.2-RELEASE/swift-5.0.2-RELEASE-osx.pkg"
+    ;;
+
+  'ubuntu14.04' )
+    URL="https://swift.org/builds/swift-5.0.2-release/ubuntu1404/swift-5.0.2-RELEASE/swift-5.0.2-RELEASE-ubuntu14.04.tar.gz"
+    ;;
+
+  'ubuntu16.04' )
+    URL="https://swift.org/builds/swift-5.0.2-release/ubuntu1604/swift-5.0.2-RELEASE/swift-5.0.2-RELEASE-ubuntu16.04.tar.gz"
+    ;;
+
+  'ubuntu18.04' )
+    URL="https://swift.org/builds/swift-5.0.2-release/ubuntu1804/swift-5.0.2-RELEASE/swift-5.0.2-RELEASE-ubuntu18.04.tar.gz"
+    ;;
+
+  * )
+    ;;
+esac

--- a/swiftenv/share/swiftenv-install/5.0.3
+++ b/swiftenv/share/swiftenv-install/5.0.3
@@ -1,0 +1,20 @@
+case "$PLATFORM" in
+  'osx' )
+    URL="https://swift.org/builds/swift-5.0.3-release/xcode/swift-5.0.3-RELEASE/swift-5.0.3-RELEASE-osx.pkg"
+    ;;
+
+  'ubuntu14.04' )
+    URL="https://swift.org/builds/swift-5.0.3-release/ubuntu1404/swift-5.0.3-RELEASE/swift-5.0.3-RELEASE-ubuntu14.04.tar.gz"
+    ;;
+
+  'ubuntu16.04' )
+    URL="https://swift.org/builds/swift-5.0.3-release/ubuntu1604/swift-5.0.3-RELEASE/swift-5.0.3-RELEASE-ubuntu16.04.tar.gz"
+    ;;
+
+  'ubuntu18.04' )
+    URL="https://swift.org/builds/swift-5.0.3-release/ubuntu1804/swift-5.0.3-RELEASE/swift-5.0.3-RELEASE-ubuntu18.04.tar.gz"
+    ;;
+
+  * )
+    ;;
+esac

--- a/swiftenv/share/swiftenv-install/5.1
+++ b/swiftenv/share/swiftenv-install/5.1
@@ -1,0 +1,20 @@
+case "$PLATFORM" in
+  'osx' )
+    URL="https://swift.org/builds/swift-5.1-release/xcode/swift-5.1-RELEASE/swift-5.1-RELEASE-osx.pkg"
+    ;;
+
+  'ubuntu14.04' )
+    URL="https://swift.org/builds/swift-5.1-release/ubuntu1404/swift-5.1-RELEASE/swift-5.1-RELEASE-ubuntu14.04.tar.gz"
+    ;;
+
+  'ubuntu16.04' )
+    URL="https://swift.org/builds/swift-5.1-release/ubuntu1604/swift-5.1-RELEASE/swift-5.1-RELEASE-ubuntu16.04.tar.gz"
+    ;;
+
+  'ubuntu18.04' )
+    URL="https://swift.org/builds/swift-5.1-release/ubuntu1804/swift-5.1-RELEASE/swift-5.1-RELEASE-ubuntu18.04.tar.gz"
+    ;;
+
+  * )
+    ;;
+esac

--- a/swiftenv/share/swiftenv-install/5.1.1
+++ b/swiftenv/share/swiftenv-install/5.1.1
@@ -1,0 +1,20 @@
+case "$PLATFORM" in
+  'osx' )
+    URL="https://swift.org/builds/swift-5.1.1-release/xcode/swift-5.1.1-RELEASE/swift-5.1.1-RELEASE-osx.pkg"
+    ;;
+
+  'ubuntu14.04' )
+    URL="https://swift.org/builds/swift-5.1.1-release/ubuntu1404/swift-5.1.1-RELEASE/swift-5.1.1-RELEASE-ubuntu14.04.tar.gz"
+    ;;
+
+  'ubuntu16.04' )
+    URL="https://swift.org/builds/swift-5.1.1-release/ubuntu1604/swift-5.1.1-RELEASE/swift-5.1.1-RELEASE-ubuntu16.04.tar.gz"
+    ;;
+
+  'ubuntu18.04' )
+    URL="https://swift.org/builds/swift-5.1.1-release/ubuntu1804/swift-5.1.1-RELEASE/swift-5.1.1-RELEASE-ubuntu18.04.tar.gz"
+    ;;
+
+  * )
+    ;;
+esac

--- a/swiftenv/share/swiftenv-install/5.1.2
+++ b/swiftenv/share/swiftenv-install/5.1.2
@@ -1,0 +1,20 @@
+case "$PLATFORM" in
+  'osx' )
+    URL="https://swift.org/builds/swift-5.1.2-release/xcode/swift-5.1.2-RELEASE/swift-5.1.2-RELEASE-osx.pkg"
+    ;;
+
+  'ubuntu14.04' )
+    URL="https://swift.org/builds/swift-5.1.2-release/ubuntu1404/swift-5.1.2-RELEASE/swift-5.1.2-RELEASE-ubuntu14.04.tar.gz"
+    ;;
+
+  'ubuntu16.04' )
+    URL="https://swift.org/builds/swift-5.1.2-release/ubuntu1604/swift-5.1.2-RELEASE/swift-5.1.2-RELEASE-ubuntu16.04.tar.gz"
+    ;;
+
+  'ubuntu18.04' )
+    URL="https://swift.org/builds/swift-5.1.2-release/ubuntu1804/swift-5.1.2-RELEASE/swift-5.1.2-RELEASE-ubuntu18.04.tar.gz"
+    ;;
+
+  * )
+    ;;
+esac

--- a/swiftenv/share/swiftenv-install/5.1.3
+++ b/swiftenv/share/swiftenv-install/5.1.3
@@ -1,0 +1,20 @@
+case "$PLATFORM" in
+  'osx' )
+    URL="https://swift.org/builds/swift-5.1.3-release/xcode/swift-5.1.3-RELEASE/swift-5.1.3-RELEASE-osx.pkg"
+    ;;
+
+  'ubuntu14.04' )
+    URL="https://swift.org/builds/swift-5.1.3-release/ubuntu1404/swift-5.1.3-RELEASE/swift-5.1.3-RELEASE-ubuntu14.04.tar.gz"
+    ;;
+
+  'ubuntu16.04' )
+    URL="https://swift.org/builds/swift-5.1.3-release/ubuntu1604/swift-5.1.3-RELEASE/swift-5.1.3-RELEASE-ubuntu16.04.tar.gz"
+    ;;
+
+  'ubuntu18.04' )
+    URL="https://swift.org/builds/swift-5.1.3-release/ubuntu1804/swift-5.1.3-RELEASE/swift-5.1.3-RELEASE-ubuntu18.04.tar.gz"
+    ;;
+
+  * )
+    ;;
+esac

--- a/swiftenv/share/swiftenv-install/5.1.4
+++ b/swiftenv/share/swiftenv-install/5.1.4
@@ -1,0 +1,20 @@
+case "$PLATFORM" in
+  'osx' )
+    URL="https://swift.org/builds/swift-5.1.4-release/xcode/swift-5.1.4-RELEASE/swift-5.1.4-RELEASE-osx.pkg"
+    ;;
+
+  'ubuntu14.04' )
+    URL="https://swift.org/builds/swift-5.1.4-release/ubuntu1404/swift-5.1.4-RELEASE/swift-5.1.4-RELEASE-ubuntu14.04.tar.gz"
+    ;;
+
+  'ubuntu16.04' )
+    URL="https://swift.org/builds/swift-5.1.4-release/ubuntu1604/swift-5.1.4-RELEASE/swift-5.1.4-RELEASE-ubuntu16.04.tar.gz"
+    ;;
+
+  'ubuntu18.04' )
+    URL="https://swift.org/builds/swift-5.1.4-release/ubuntu1804/swift-5.1.4-RELEASE/swift-5.1.4-RELEASE-ubuntu18.04.tar.gz"
+    ;;
+
+  * )
+    ;;
+esac

--- a/swiftenv/share/swiftenv-install/5.1.5
+++ b/swiftenv/share/swiftenv-install/5.1.5
@@ -1,0 +1,20 @@
+case "$PLATFORM" in
+  'osx' )
+    URL="https://swift.org/builds/swift-5.1.5-release/xcode/swift-5.1.5-RELEASE/swift-5.1.5-RELEASE-osx.pkg"
+    ;;
+
+  'ubuntu14.04' )
+    URL="https://swift.org/builds/swift-5.1.5-release/ubuntu1404/swift-5.1.5-RELEASE/swift-5.1.5-RELEASE-ubuntu14.04.tar.gz"
+    ;;
+
+  'ubuntu16.04' )
+    URL="https://swift.org/builds/swift-5.1.5-release/ubuntu1604/swift-5.1.5-RELEASE/swift-5.1.5-RELEASE-ubuntu16.04.tar.gz"
+    ;;
+
+  'ubuntu18.04' )
+    URL="https://swift.org/builds/swift-5.1.5-release/ubuntu1804/swift-5.1.5-RELEASE/swift-5.1.5-RELEASE-ubuntu18.04.tar.gz"
+    ;;
+
+  * )
+    ;;
+esac

--- a/swiftenv/test/install.bats
+++ b/swiftenv/test/install.bats
@@ -88,3 +88,13 @@ load helpers
   [ "$lines" = "1.0.0 is already installed." ]
   [ ! -r "$SWIFTENV_ROOT/version" ]
 }
+
+@test "does't allow --no-user on non-macOS" {
+  if [[ "$(uname)" == "Darwin" ]]; then
+    skip
+  fi
+
+  run swiftenv install 4.1 --no-user
+  [ "$status" -eq 1 ]
+  [ "$lines" = "--no-user installation is only supported on macOS." ]
+}


### PR DESCRIPTION
Swiftenv never used the bundled URLs because the PLATFORM environment variable was set after sourcing the version script. This PR fixes that, so the tool no longer talks home all the time, plus adds URLs for 5.0.2-5.1.5.