### PR TITLE
Swift 5.2 update and new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,11 @@ $ heroku create --buildpack vapor/vapor
 
 $ git push heroku master
 remote: -----> Swift app detected
-remote: -----> Installing clang 7.0.1
+remote: -----> Using Swift 5.2.1 (default)
+remote: -----> Using built-in clang (Swift 5.2.1)
 remote: -----> Installing swiftenv
-remote: -----> Installing Swift 4.2.4
-remote: -----> Building package (release configuration)
-remote: -----> Installing dynamic libraries
-remote: -----> Installing binaries
+remote: -----> Installing Swift 5.2.1
+...
 ```
 
 You can also add it to upcoming builds of an existing application:
@@ -37,35 +36,44 @@ Using the Procfile, you can set the process to run for your web server. Any
 binaries built from your Swift source using swift package manager will
 be placed in your $PATH.
 
+Example Procfile for Vapor 3 and 4 apps:
+
+```
+web: Run serve --env production --hostname 0.0.0.0 --port $PORT
+```
+
 Example Procfile for Vapor 2 apps:
 
 ```
 web: Run --env=production --port=$PORT
 ```
 
-Example Procfile for Vapor 3 apps:
-
-```
-web: Run serve --env production --hostname 0.0.0.0 --port $PORT
-```
-
 ### Specify a Swift version
 
-The buildpack defaults to Swift 4.2.4 to maintain compatibility with Swift 3 projects. If you want to use the latest and greatest, or need a specific version – including snapshots, create a file called `.swift-version` in the root of the project folder with the desired version number inside. 
+The buildpack defaults to Swift 5.2.1 which will be swiftly updated when new Swift versions are released.
+
+If you need to use a specific version of the Swift toolchain, including older versions – for example Swift 4.2.x to retain compatibility with Swift 3 projects, you can pin that version number using a file called `.swift-version` in the root of the project folder, or by setting a `SWIFT_VERSION` configuration variable on Heroku, then deploying again. 
 
 ```shell
-$ echo '5.0.3' > .swift-version
+$ echo '5.1.5' > .swift-version
+$ git add .swift-version
+$ git commit -m "Pin Swift version to 5.1.5"
+$ git push heroku master
 ```
 
-The `.swift-version` file is completely compatible with
-[swiftenv](http://github.com/kylef/swiftenv).
+Or:
 
-**NOTE**: *Since there are frequent Swift language changes, it's advised that
-you pin to your Swift version.*
+```shell
+$ heroku config:set SWIFT_VERSION=5.1.5
+$ git commit -m "Pin Swift version to 5.1.5" --allow-empty
+$ git push heroku master
+```
+
+The version format used file is compatible with [swiftenv](http://github.com/kylef/swiftenv).
 
 ### Active build configuration
 
-By default, the buildpack will use the `release` build configuration to enable compiler optimizations. If you are experiencing mysterious crashes, you can try disabling them by setting the `SWIFT_BUILD_CONFIGURATION` to `debug`, then redeploying.
+By default, the buildpack will use the `release` build configuration to enable compiler optimizations. If you are experiencing mysterious crashes, you can try disabling them by setting the `SWIFT_BUILD_CONFIGURATION` config variable to `debug`, then redeploying.
 
 ```shell
 $ heroku config:set SWIFT_BUILD_CONFIGURATION=debug
@@ -75,6 +83,22 @@ $ git push heroku master
 remote: -----> Building package (debug configuration)
 ...
 ```
+
+### Other build arguments
+
+If you want to pass in extra flags to `swift build`, you can do so using the `SWIFT_BUILD_FLAGS` config variable.
+
+For example, the excellent [swift-backtrace](https://github.com/swift-server/swift-backtrace) library needs debug symbols, which can be enabled by passing `-Xswiftc -g` to the build command. Or, if you want to leverage test discovery instead of generating/writing Linux test manifests, the `--enable-test-discovery` flag is really useful.
+
+The following example shows how to set both:
+
+```shell
+$ heroku config:set SWIFT_BUILD_FLAGS="--enable-test-discovery -Xswiftc -g"
+$ git commit -m "Enable test discovery and debug symbols on Heroku" --allow-empty
+$ git push heroku master
+```
+
+Note: while the buildpack does not run tests, having a test manifest or enabling test discovery is mandatory at the time of writing.
 
 ### Hooks
 
@@ -90,6 +114,6 @@ This is useful if you would need to install any other dependencies.
 
 The `vapor/vapor` buildpack from the [Heroku Buildpack Registry](https://devcenter.heroku.com/articles/buildpack-registry) represents the latest stable version of the buildpack. If you'd like to use the source code from this Github repository, you can set your buildpack to the Github URL:
 
-```sh-session
+```shell
 $ heroku buildpacks:set https://github.com/vapor-community/heroku-buildpack.git
 ```

--- a/bin/compile
+++ b/bin/compile
@@ -18,6 +18,9 @@ SWIFT_VERSION="5.2.1"
 SWIFT_BUILD_CONFIGURATION="release"
 SWIFT_BUILD_FLAGS=""
 
+source "/etc/lsb-release"
+source "$BIN_DIR/utils"
+
 if [ -f "$BUILD_DIR/.swift-version" ]; then
   SWIFT_VERSION=`cat $BUILD_DIR/.swift-version | tr -d '[[:space:]]'`
   puts-step "Using Swift $SWIFT_VERSION (from .swift-version file)"
@@ -38,9 +41,6 @@ fi
 
 
 mkdir -p "$CACHE_DIR/$STACK"
-
-source "/etc/lsb-release"
-source "$BIN_DIR/utils"
 
 if [[ $SWIFT_VERSION = 5* ]]; then
   puts-step "Using built-in clang (Swift $SWIFT_VERSION)"

--- a/bin/compile
+++ b/bin/compile
@@ -11,24 +11,43 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
 
-DEFAULT_SWIFT_VERSION="4.2.4"
 
 CLANG_VERSION=7.0.1
+
+SWIFT_VERSION="5.2.1"
 SWIFT_BUILD_CONFIGURATION="release"
 SWIFT_BUILD_FLAGS=""
+
+if [ -f "$BUILD_DIR/.swift-version" ]; then
+  SWIFT_VERSION=`cat $BUILD_DIR/.swift-version | tr -d '[[:space:]]'`
+  puts-step "Using Swift $SWIFT_VERSION (from .swift-version file)"
+elif [ -f "$ENV_DIR/SWIFT_VERSION" ]; then
+  SWIFT_VERSION=`cat $ENV_DIR/SWIFT_VERSION | tr -d '[[:space:]]'`
+  puts-step "Using Swift $SWIFT_VERSION (from SWIFT_VERSION config)"
+else
+  puts-step "Using Swift $SWIFT_VERSION (default)"
+fi
 
 if [ -f "$ENV_DIR/SWIFT_BUILD_CONFIGURATION" ]; then
   SWIFT_BUILD_CONFIGURATION=`cat "$ENV_DIR/SWIFT_BUILD_CONFIGURATION"`
 fi
+
 if [ -f "$ENV_DIR/SWIFT_BUILD_FLAGS" ]; then
   SWIFT_BUILD_FLAGS=`cat "$ENV_DIR/SWIFT_BUILD_FLAGS"`
 fi
+
 
 mkdir -p "$CACHE_DIR/$STACK"
 
 source "/etc/lsb-release"
 source "$BIN_DIR/utils"
-source "$BIN_DIR/steps/clang"
+
+if [[ $SWIFT_VERSION = 5* ]]; then
+  puts-step "Using built-in clang (Swift $SWIFT_VERSION)"
+else
+  source "$BIN_DIR/steps/clang"
+fi
+
 source "$BIN_DIR/steps/swiftenv"
 
 cd $BUILD_DIR

--- a/bin/steps/swiftenv
+++ b/bin/steps/swiftenv
@@ -5,12 +5,6 @@ export SWIFTENV_ROOT="$CACHE_DIR/$STACK/swiftenv"
 export PATH="$ROOT_DIR/swiftenv/bin:$PATH"
 eval "$(swiftenv init -)"
 
-if [ -f "$BUILD_DIR/.swift-version" ]; then
-    export SWIFT_VERSION=`cat $BUILD_DIR/.swift-version | tr -d '[[:space:]]'`
-else 
-    export SWIFT_VERSION="$DEFAULT_SWIFT_VERSION"
-fi
-
 # Install Swift
 puts-step Installing Swift $SWIFT_VERSION
 swiftenv install $SWIFT_VERSION -s


### PR DESCRIPTION
With this PR in:

- The default Swift version will be 5.2.1, with the promise that it will be updated quickly as new toolchains drop.

    _Living legacy projects can still pin old versions manually._

- On top of the `.swift-version` file, the `SWIFT_VERSION` configuration variable can be used to specify the pinned Swift version too.

    _This helps consistency with other build parameters and may be easier to explain than the hidden file._

- Clang is no longer installed for Swift 5.x.

    _It was just wasted build time and cache space anyway._

- The README has a practical example for SWIFT_BUILD_FLAGS.