### PR TITLE
Copy resources to build directory

### DIFF
--- a/bin/steps/swift-install
+++ b/bin/steps/swift-install
@@ -12,7 +12,7 @@ mkdir -p $BUILD_DIR/.swift-bin
 find -L .build/$SWIFT_BUILD_CONFIGURATION ! -regex "$DYNAMIC_LIBRARY_REGEX" -type f -perm /a+x -exec cp -a {} $BUILD_DIR/.swift-bin \; || true 2>/dev/null
 
 puts-step "Installing resources"
-find -L .build/$SWIFT_BUILD_CONFIGURATION/* -regex '.*\.bundle$' -exec cp -a {} $BUILD_DIR/.swift-bin \; || true 2>/dev/null
+find -L .build/$SWIFT_BUILD_CONFIGURATION/* -regex '.*\.resources$' -exec cp -a {} $BUILD_DIR/.swift-bin \; || true 2>/dev/null
 
 puts-step "Cleaning up after build"
 rm -rf .build

--- a/bin/steps/swift-install
+++ b/bin/steps/swift-install
@@ -11,5 +11,8 @@ puts-step "Installing binaries"
 mkdir -p $BUILD_DIR/.swift-bin
 find -L .build/$SWIFT_BUILD_CONFIGURATION ! -regex "$DYNAMIC_LIBRARY_REGEX" -type f -perm /a+x -exec cp -a {} $BUILD_DIR/.swift-bin \; || true 2>/dev/null
 
+puts-step "Installing resources"
+find -L .build/$SWIFT_BUILD_CONFIGURATION/* -regex '.*\.bundle$' -exec cp -a {} $BUILD_DIR/.swift-bin \; || true 2>/dev/null
+
 puts-step "Cleaning up after build"
 rm -rf .build


### PR DESCRIPTION
This adds an install step to copy any `.resources` directory to the build directory. Fixes #58 