### PR TITLE
Pass on Heroku-provided directories to hooks

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -50,7 +50,7 @@ fi
 source "$BIN_DIR/steps/swiftenv"
 
 cd $BUILD_DIR
-source "$BIN_DIR/steps/hooks/pre_compile"
+source "$BIN_DIR/steps/hooks/pre_compile" "$BUILD_DIR" "$CACHE_DIR" "$ENV_DIR"
 source "$BIN_DIR/steps/ssh"
 source "$BIN_DIR/steps/swift-build"
 if [[ -z "$RUN_TESTS" ]]; then
@@ -63,4 +63,4 @@ mkdir -p $BUILD_DIR/.profile.d
 set-env PATH '$HOME/.swift-bin:$PATH'
 set-env LD_LIBRARY_PATH '$LD_LIBRARY_PATH:$HOME/.swift-lib'
 
-source "$BIN_DIR/steps/hooks/post_compile"
+source "$BIN_DIR/steps/hooks/post_compile" "$BUILD_DIR" "$CACHE_DIR" "$ENV_DIR"


### PR DESCRIPTION
This PR enables access to the build/cache/env directory paths from within your pre/post-compilation hooks, which is tremendously useful.