### PR TITLE
Invoke post_compile hook before install and add pre/post_install hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,13 @@ $ git push heroku master
 
 ### Hooks
 
-You can place custom scripts to be run before and after compiling your Swift
+You can place custom scripts to be run before and after compiling and installing your Swift
 source code inside the following files in your repository:
 
 - `bin/pre_compile`
 - `bin/post_compile`
+- `bin/pre_install`
+- `bin/post_install`
 
 This is useful if you need to customize the final image.
 

--- a/bin/compile
+++ b/bin/compile
@@ -55,7 +55,9 @@ source "$BIN_DIR/steps/ssh"
 source "$BIN_DIR/steps/swift-build"
 source "$BIN_DIR/steps/hooks/post_compile" "$BUILD_DIR" "$CACHE_DIR" "$ENV_DIR"
 if [[ -z "$RUN_TESTS" ]]; then
+  source "$BIN_DIR/steps/hooks/pre_install" "$BUILD_DIR" "$CACHE_DIR" "$ENV_DIR"
   source "$BIN_DIR/steps/swift-install"
+  source "$BIN_DIR/steps/hooks/post_install" "$BUILD_DIR" "$CACHE_DIR" "$ENV_DIR"
 fi
 
 # Setup application environment
@@ -63,5 +65,3 @@ mkdir -p $BUILD_DIR/.profile.d
 
 set-env PATH '$HOME/.swift-bin:$PATH'
 set-env LD_LIBRARY_PATH '$LD_LIBRARY_PATH:$HOME/.swift-lib'
-
-source "$BIN_DIR/steps/hooks/post_compile" "$BUILD_DIR" "$CACHE_DIR" "$ENV_DIR"

--- a/bin/compile
+++ b/bin/compile
@@ -53,6 +53,7 @@ cd $BUILD_DIR
 source "$BIN_DIR/steps/hooks/pre_compile" "$BUILD_DIR" "$CACHE_DIR" "$ENV_DIR"
 source "$BIN_DIR/steps/ssh"
 source "$BIN_DIR/steps/swift-build"
+source "$BIN_DIR/steps/hooks/post_compile" "$BUILD_DIR" "$CACHE_DIR" "$ENV_DIR"
 if [[ -z "$RUN_TESTS" ]]; then
   source "$BIN_DIR/steps/swift-install"
 fi

--- a/bin/steps/hooks/post_install
+++ b/bin/steps/hooks/post_install
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [ -f bin/post_install ]; then
+  echo "-----> Running post-install hook"
+  chmod +x bin/post_install
+  ./bin/post_install
+fi

--- a/bin/steps/hooks/pre_install
+++ b/bin/steps/hooks/pre_install
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+if [ -f bin/pre_install ]; then
+  echo "-----> Running pre-install hook"
+  source ./bin/pre_install
+fi


### PR DESCRIPTION
### Changing time of hook execution

This PR moves the invocation of the post_compile script up some lines, right after `swift-compile` has completed and before `swift-install` is executed.

It also adds a pre_install and a post_install hook too.

### Description

I have a task which must be executed against the .build folder. Mainly a script that copies the `/Resources/*` folder out of a dependent package. (I'm using Leaf in a dependency, but Leaf is unable to render files that are packaged with SPM in a dependency).

Therefore, I tried a post_compile script like `cp -r $BUILD_DIR/.build/checkouts/repo/Resources .`

But since the `post_compile` script is executed after `swift-install`, the `.build` folder is already gone. This PR resolves this case.